### PR TITLE
chore: bump SDK version to 24.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ repositories {
 Next, add the dependency to your project's `build.gradle(.kts)` file:
 
 ```groovy
-implementation("io.appwrite:sdk-for-android:24.1.1")
+implementation("io.appwrite:sdk-for-android:24.2.0")
 ```
 
 ### Maven
@@ -49,7 +49,7 @@ Add this to your project's `pom.xml` file:
     <dependency>
         <groupId>io.appwrite</groupId>
         <artifactId>sdk-for-android</artifactId>
-        <version>24.1.1</version>
+        <version>24.2.0</version>
     </dependency>
 </dependencies>
 ```


### PR DESCRIPTION
This PR bumps the SDK package version to 24.2.0 after the concurrent chunk upload update.